### PR TITLE
Dynamically load source drivers by name

### DIFF
--- a/health/drivers/tcp/driver.py
+++ b/health/drivers/tcp/driver.py
@@ -142,7 +142,8 @@ def record_from_bucket(bucket, timestamp, service):
     return record
 
 
-def main(es, latest_aggregated_ts=None):
+def main(config, latest_aggregated_ts=None):
+    es = config["elastic_src"]
     ts_min, ts_max = utils.get_min_max_timestamps(es, "Timestamp")
 
     if latest_aggregated_ts:


### PR DESCRIPTION
Health job now loads driver modules dynamically, by it's type. If
source's driver type is "foo" it expects 'health.drivers.foo.driver' to
be present and to contain main function, that will be passed driver
configuration and max timestamp.