### PR TITLE
Fix health region API

### DIFF
--- a/health/api/v1/health_.py
+++ b/health/api/v1/health_.py
@@ -129,12 +129,12 @@ def get_health(region, period):
 
     result = {
         "project_names": [],
-        "projects": {}
+        "health": {}
     }
 
     for project in r.json()["aggregations"]["projects"]["buckets"]:
         result["project_names"].append(project["key"])
-        result["projects"][project["key"]] = {
+        result["health"][project["key"]] = {
             "api_calls_count": project["api_calls_count"]["value"],
             "api_calls_count_data": convert(project["data"], "api_count"),
             "fci": project["fci"]["value"],

--- a/tests/unit/api/v1/test_health.py
+++ b/tests/unit/api/v1/test_health.py
@@ -80,7 +80,7 @@ class RegionsTestCase(base.APITestCase):
         resp_json = json.loads(resp.data.decode())
         self.assertEqual(200, resp.status_code)
         self.assertEqual(set(self.services), set(resp_json["project_names"]))
-        self.assertEqual(set(self.services), set(resp_json["projects"].keys()))
+        self.assertEqual(set(self.services), set(resp_json["health"].keys()))
 
         request_args, request_kwargs = mock_request.call_args
         self.assertEqual(


### PR DESCRIPTION
Change format "projects" -> "health" makes it way simpler for other
services to work with